### PR TITLE
Handling success for the same page should not remove the identifiers

### DIFF
--- a/core/src/store/redux/reducers.ts
+++ b/core/src/store/redux/reducers.ts
@@ -1,31 +1,32 @@
 import { updateItem } from "./functions";
-import {AnyAction} from "redux";
+import { AnyAction } from "redux";
 
 export type ItemsResolver = (action: AnyAction) => any[];
 export type ItemsOption = any[] | ItemsResolver;
 export type ReduceItemsOptions = {
   items: ItemsOption;
   itemIdentifierResolver: (item: object) => string;
-  itemTransformer?: (item : object) => object;
+  itemTransformer?: (item: object) => object;
 };
 
 export type ActionLifecycle = {
   starting: string;
   failed: string;
   succeed: string;
-}
+};
 
 export type ActionLifecycleOptions = {
   actionPrefix?: string;
   actions: ActionLifecycle;
-}
-
-export type ReduceListOptions = ReduceItemsOptions & ActionLifecycleOptions & {
-  listKeyInState: string;
-
-  errorMessageResolver?: (action: AnyAction) => string;
-  totalItems?: (action: AnyAction) => number;
 };
+
+export type ReduceListOptions = ReduceItemsOptions &
+  ActionLifecycleOptions & {
+    listKeyInState: string;
+
+    errorMessageResolver?: (action: AnyAction) => string;
+    totalItems?: (action: AnyAction) => number;
+  };
 
 export type ReducedList = {
   identifiers: string[];
@@ -39,37 +40,34 @@ export type ReducedList = {
 const resolveActionsToHandle = (options: ReduceListOptions) => {
   if (options.actionPrefix) {
     options.actions = {
-      starting: options.actionPrefix+'_SENT',
-      failed: options.actionPrefix+'_FAILED',
-      succeed: options.actionPrefix+'_RECEIVED',
-    }
+      starting: options.actionPrefix + "_SENT",
+      failed: options.actionPrefix + "_FAILED",
+      succeed: options.actionPrefix + "_RECEIVED"
+    };
   }
 
   return options.actions;
 };
 
-export const reduceListAndItems = (state = {}, action : AnyAction, options : ReduceListOptions) => {
+export const reduceListAndItems = (
+  state = {},
+  action: AnyAction,
+  options: ReduceListOptions
+) => {
   const actions = resolveActionsToHandle(options);
-  const actionTypes = Object.keys(actions).map((key: 'starting' | 'failed' | 'succeed') => actions[key]);
+  const actionTypes = Object.keys(actions).map(
+    (key: "starting" | "failed" | "succeed") => actions[key]
+  );
   if (actionTypes.indexOf(action.type) === -1) {
     return state;
   }
 
-  return reduceList(
-    reduceItems(
-      state,
-      action,
-      options
-    ),
-    action,
-    options
-  );
+  return reduceList(reduceItems(state, action, options), action, options);
 };
 
 function itemsFromAction(action: AnyAction, options: ReduceItemsOptions) {
-  let items = 'function' === typeof options.items
-    ? options.items(action)
-    : options.items;
+  let items =
+    "function" === typeof options.items ? options.items(action) : options.items;
 
   if (options.itemTransformer) {
     items = items.map(options.itemTransformer);
@@ -81,10 +79,16 @@ function itemsFromAction(action: AnyAction, options: ReduceItemsOptions) {
 const defaultErrorMessageResolver = (action: AnyAction) => {
   const messageSource = action.error || action.payload || {};
 
-  return messageSource.message || messageSource.error || 'Something went wrong.';
+  return (
+    messageSource.message || messageSource.error || "Something went wrong."
+  );
 };
 
-export const reduceItems = (state = {}, action : AnyAction, options : ReduceItemsOptions) => {
+export const reduceItems = (
+  state = {},
+  action: AnyAction,
+  options: ReduceItemsOptions
+) => {
   let items = itemsFromAction(action, options);
 
   for (let i = 0; i < items.length; i++) {
@@ -96,7 +100,11 @@ export const reduceItems = (state = {}, action : AnyAction, options : ReduceItem
   return state;
 };
 
-export const reduceList = (state : any = {}, action : AnyAction, options : ReduceListOptions) : ReducedList => {
+export const reduceList = (
+  state: any = {},
+  action: AnyAction,
+  options: ReduceListOptions
+): ReducedList => {
   const actions = resolveActionsToHandle(options);
 
   // If the list does not exists.
@@ -107,37 +115,49 @@ export const reduceList = (state : any = {}, action : AnyAction, options : Reduc
   if (action.type === actions.starting) {
     return updateItem(state, options.listKeyInState, {
       loading: true,
-      error: null,
+      error: null
     });
   }
 
   if (action.type === actions.succeed) {
     const items = itemsFromAction(action, options);
-    const totalItems = 'function' === typeof options.totalItems
-      ? options.totalItems(action)
-      : undefined;
+    const totalItems =
+      "function" === typeof options.totalItems
+        ? options.totalItems(action)
+        : undefined;
 
     const loadedIdentifiers = items.map(options.itemIdentifierResolver);
-    const identifiers = action.meta && state[options.listKeyInState].up_to_page < action.meta.page
-      // Adds
-      ? state[options.listKeyInState].identifiers.concat(loadedIdentifiers)
 
-      // Replaces
-      : loadedIdentifiers;
+    // Ignore if current page was already loaded
+    if (
+      action.meta &&
+      state[options.listKeyInState].up_to_page == action.meta.page
+    ) {
+      return state;
+    }
+
+    const identifiers =
+      action.meta && state[options.listKeyInState].up_to_page < action.meta.page
+        ? // Adds
+          state[options.listKeyInState].identifiers.concat(loadedIdentifiers)
+        : // Replaces
+          loadedIdentifiers;
 
     return updateItem(state, options.listKeyInState, {
       identifiers,
       up_to_page: action.meta && action.meta.page,
       loading: false,
-      total_items: totalItems,
+      total_items: totalItems
     });
   }
 
   if (action.type === actions.failed) {
-    const errorResolver = options.errorMessageResolver ? options.errorMessageResolver : defaultErrorMessageResolver;
+    const errorResolver = options.errorMessageResolver
+      ? options.errorMessageResolver
+      : defaultErrorMessageResolver;
     return updateItem(state, options.listKeyInState, {
       loading: false,
-      error: errorResolver(action),
+      error: errorResolver(action)
     });
   }
 

--- a/core/tests/store/redux/reducers.list.test.ts
+++ b/core/tests/store/redux/reducers.list.test.ts
@@ -1,124 +1,243 @@
-import {reduceList} from "../../../src/store/redux/reducers";
+import { reduceList } from "../../../src/store/redux/reducers";
 
-describe('Reduce list of items', () => {
-  it('sets the loading status when starting', () => {
-    const reduced = reduceList(undefined, {
-      type: 'MY_ACTION_SENT',
-    }, {
-      items: [],
-      itemIdentifierResolver: (item : any) => item.id,
-      actionPrefix: 'MY_ACTION',
-      listKeyInState: 'list'
-    })
+describe("Reduce list of items", () => {
+  it("sets the loading status when starting", () => {
+    const reduced = reduceList(
+      undefined,
+      {
+        type: "MY_ACTION_SENT"
+      },
+      {
+        items: [],
+        itemIdentifierResolver: (item: any) => item.id,
+        actionPrefix: "MY_ACTION",
+        listKeyInState: "list"
+      }
+    );
 
     expect(reduced).toEqual({
       list: {
         loading: true,
         error: null
       }
-    })
-  })
+    });
+  });
 
-  it('sets the error when this happens', () => {
-    const reduced = reduceList({
-      list: {
-        loading: true,
-        error: null,
+  it("sets the error when this happens", () => {
+    const reduced = reduceList(
+      {
+        list: {
+          loading: true,
+          error: null
+        }
+      },
+      {
+        type: "MY_ACTION_FAILED",
+        payload: {
+          message: "Invalid something..."
+        }
+      },
+      {
+        items: [],
+        itemIdentifierResolver: (item: any) => item.id,
+        actionPrefix: "MY_ACTION",
+        listKeyInState: "list"
       }
-    }, {
-      type: 'MY_ACTION_FAILED',
-      payload: {
-        message: 'Invalid something...'
-      }
-    }, {
-      items: [],
-      itemIdentifierResolver: (item : any) => item.id,
-      actionPrefix: 'MY_ACTION',
-      listKeyInState: 'list'
-    })
+    );
 
     expect(reduced).toEqual({
       list: {
         loading: false,
-        error: 'Invalid something...'
+        error: "Invalid something..."
       }
-    })
-  })
+    });
+  });
 
-  it('set the list item identifiers', () => {
-    const reduced = reduceList({
-      list: {
-        loading: true,
+  it("set the list item identifiers", () => {
+    const reduced = reduceList(
+      {
+        list: {
+          loading: true
+        }
+      },
+      {
+        type: "MY_ACTION_RECEIVED"
+      },
+      {
+        items: [
+          { id: 1, name: "Foo" },
+          { id: 2, name: "Bar" }
+        ],
+        itemIdentifierResolver: (item: any) => item.id,
+        actionPrefix: "MY_ACTION",
+        listKeyInState: "list"
       }
-    }, {
-      type: 'MY_ACTION_RECEIVED',
-    }, {
-      items: [{id: 1, name: 'Foo'}, {id: 2, name: 'Bar'}],
-      itemIdentifierResolver: (item : any) => item.id,
-      actionPrefix: 'MY_ACTION',
-      listKeyInState: 'list'
-    })
+    );
 
     expect(reduced).toEqual({
       list: {
         loading: false,
         identifiers: [1, 2],
         total_items: undefined,
-        up_to_page: undefined,
+        up_to_page: undefined
       }
-    })
-  })
+    });
+  });
 
-  it('supports to specify each action', () => {
+  it("loads further pages", () => {
+    const options = {
+      itemIdentifierResolver: (item: any) => item.id,
+      actionPrefix: "MY_ACTION",
+      listKeyInState: "list",
+      items: action => action.payload
+    };
+
+    let state = {};
+    let state = reduceList(
+      state,
+      {
+        type: "MY_ACTION_SENT"
+      },
+      options
+    );
+
+    let state = reduceList(
+      state,
+      {
+        type: "MY_ACTION_RECEIVED",
+        payload: [{ id: "1234" }],
+        meta: {
+          page: 1
+        }
+      },
+      options
+    );
+
+    let state = reduceList(
+      state,
+      {
+        type: "MY_ACTION_RECEIVED",
+        payload: [{ id: "5678" }],
+        meta: {
+          page: 2
+        }
+      },
+      options
+    );
+
+    expect(state).toMatchObject({
+      list: expect.objectContaining({
+        identifiers: ["1234", "5678"]
+      })
+    });
+  });
+
+  it("loads further pages in an idempotent way", () => {
+    const options = {
+      itemIdentifierResolver: (item: any) => item.id,
+      actionPrefix: "MY_ACTION",
+      listKeyInState: "list",
+      items: action => action.payload
+    };
+
+    let state = {};
+    let state = reduceList(
+      state,
+      {
+        type: "MY_ACTION_SENT"
+      },
+      options
+    );
+
+    let state = reduceList(
+      state,
+      {
+        type: "MY_ACTION_RECEIVED",
+        payload: [{ id: "1234" }],
+        meta: {
+          page: 1
+        }
+      },
+      options
+    );
+
+    const secondPageReceived = {
+      type: "MY_ACTION_RECEIVED",
+      payload: [{ id: "5678" }],
+      meta: {
+        page: 2
+      }
+    };
+
+    let state = reduceList(state, secondPageReceived, options);
+    let state = reduceList(state, secondPageReceived, options);
+
+    expect(state).toMatchObject({
+      list: expect.objectContaining({
+        identifiers: ["1234", "5678"]
+      })
+    });
+  });
+
+  it("supports to specify each action", () => {
     let state = {};
     const reducerOptions = {
       items: [],
-      itemIdentifierResolver: (item : any) => item.id,
+      itemIdentifierResolver: (item: any) => item.id,
       actions: {
-        starting: 'MY_ACTION_STARTING',
-        failed: 'IT_DID_FAIL',
-        succeed: 'YAY'
+        starting: "MY_ACTION_STARTING",
+        failed: "IT_DID_FAIL",
+        succeed: "YAY"
       },
-      listKeyInState: 'list'
+      listKeyInState: "list"
     };
 
-    state = reduceList(state, { type: 'MY_ACTION_FAILED' }, reducerOptions);
-    state = reduceList(state, { type: 'IT_DID_FAIL', error: { oups: 'Meh'} }, reducerOptions);
+    state = reduceList(state, { type: "MY_ACTION_FAILED" }, reducerOptions);
+    state = reduceList(
+      state,
+      { type: "IT_DID_FAIL", error: { oups: "Meh" } },
+      reducerOptions
+    );
 
     expect(state).toEqual({
       list: {
         loading: false,
-        error: 'Something went wrong.'
+        error: "Something went wrong."
       }
-    })
-  })
+    });
+  });
 
-  it('supports a custom error message resolver', () => {
-    const reduced = reduceList({
-      list: {
-        loading: true,
-        error: null,
-      }
-    }, {
-      type: 'MY_ACTION_FAILED',
-      payload: {
-        error: {
-          myComplexErrorSchema: 'With a message'
+  it("supports a custom error message resolver", () => {
+    const reduced = reduceList(
+      {
+        list: {
+          loading: true,
+          error: null
         }
+      },
+      {
+        type: "MY_ACTION_FAILED",
+        payload: {
+          error: {
+            myComplexErrorSchema: "With a message"
+          }
+        }
+      },
+      {
+        items: [],
+        itemIdentifierResolver: (item: any) => item.id,
+        actionPrefix: "MY_ACTION",
+        listKeyInState: "list",
+        errorMessageResolver: (action: any) =>
+          action.payload.error.myComplexErrorSchema
       }
-    }, {
-      items: [],
-      itemIdentifierResolver: (item : any) => item.id,
-      actionPrefix: 'MY_ACTION',
-      listKeyInState: 'list',
-      errorMessageResolver: (action: any) => action.payload.error.myComplexErrorSchema,
-    })
+    );
 
     expect(reduced).toEqual({
       list: {
         loading: false,
-        error: 'With a message'
+        error: "With a message"
       }
-    })
-  })
-})
+    });
+  });
+});


### PR DESCRIPTION
If the page is the same... we don't override the items.