### PR TITLE
Add an option to disable the refresh animation for ScrollableCollection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 node_modules/
 dist/
 .jest/
-package-lock.json
-yarn.lock
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 dist/
 .jest/
+package-lock.json
+yarn.lock
+.idea

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@birdiecare/galette-native",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/native/src/collection/components/ScrollableCollection.tsx
+++ b/native/src/collection/components/ScrollableCollection.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ReactNode } from "react";
-import { RefreshControl, ScrollView, StyleProp, ViewStyle } from "react-native";
+import { RefreshControl, StyleProp, ViewStyle } from "react-native";
 import CollectionComponent, {
   Props as CollectionComponentProps
 } from "./CollectionComponent";
@@ -9,6 +9,7 @@ import Collection from "../Collection";
 type Props = CollectionComponentProps & {
   collection: Collection;
   onRefresh: (page?: number) => void;
+  hideRefreshAnimation?: boolean;
   header?: ReactNode;
   numberOfItemsForFullPage?: StyleProp<ViewStyle>;
   style?: any;
@@ -25,7 +26,7 @@ export default class ScrollableCollection extends Component<Props, {}> {
   }
 
   render() {
-    let { collection } = this.props;
+    let { collection, hideRefreshAnimation } = this.props;
 
     return (
       <React.Fragment>
@@ -34,7 +35,7 @@ export default class ScrollableCollection extends Component<Props, {}> {
           style={this.props.style || { flex: 1 }}
           refreshControl={
             <RefreshControl
-              refreshing={collection.isLoading()}
+              refreshing={!hideRefreshAnimation && collection.isLoading()}
               onRefresh={() => this.props.onRefresh(1)}
               title="Loading..."
               tintColor="#fff"


### PR DESCRIPTION
## What does this PR do?

Add a new optional boolean prop `hideRefreshAnimation` for the ScrollableCollection. If set to `true`, it will hide the native loader provided by react-native `RefreshControl`.
The default is `undefined` to preserve backward compatibility.

## Why making this addition?

When running mobile E2E tests with Detox, the tests are hanging on the animation.
I have a consistent reproduction and making this change in the galette node module consistently fixes it.

![Screenshot 2021-02-08 at 11 14 50](https://user-images.githubusercontent.com/32410558/107216016-6913f700-6a0c-11eb-8f4d-9308eb9f1dfe.png)
